### PR TITLE
fix resources order

### DIFF
--- a/lib/awsrm/generator/doc/resource.rb
+++ b/lib/awsrm/generator/doc/resource.rb
@@ -8,7 +8,8 @@ module Awsrm
             resources = Dir.glob(resource_dir + '*').map do |file|
               File.basename(file, '.rb')
             end
-            links = resources.sort.map do |r|
+            resources.sort!
+            links = resources.map do |r|
               '[' + r.classify + '](#' + r + ')'
             end
             header = <<-'EOF'


### PR DESCRIPTION
```bundle exec rspec spec/generator/doc/resource_spec.rb``` is faild because detail of resources order is different from index's.
So I fixed order.